### PR TITLE
Fixes to get the extension working on HifiberryOS64 Alpha 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ EXPOSE 1704
 USER snapcast
 
 # Run Snapcast server
-CMD ["/usr/bin/python3" , "/snapcastmpris/snapcastmpris.py", "-m", "$CURRENT_MIXER_CONTROL"]
+CMD ["/usr/bin/python3" , "/snapcastmpris/snapcastmpris/snapcastmpris.py", "-m", "$CURRENT_MIXER_CONTROL"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,16 @@ RUN apk update && apk add --no-cache \
     soxr-dev \
     pkgconf \
     boost-dev \
-    alsa-lib-dev \
+    alsa-lib \
     dbus-dev \
     glib-dev \
     cairo \
     cairo-dev \
     gobject-introspection-dev \
     python3 \
-    py3-pip
+    py3-pip \
+    openssl \
+    openssl-dev
 
 RUN apk add --no-cache dbus
 
@@ -49,6 +51,14 @@ FROM alpine:3.19
 RUN apk update && apk add --no-cache \
     dbus \
     glib \
+## new
+    alsa-lib \
+    opus \
+    libvorbis \
+    libflac \
+    soxr \
+    alsa-utils \
+## end new
     gobject-introspection \
     py3-gobject3 \
     py3-gobject3-dev \
@@ -56,6 +66,7 @@ RUN apk update && apk add --no-cache \
     addgroup -S snapcast -g 2001 && \
     adduser -S -D -H -G snapcast -u 2002 snapcast && \
     rm -rf /var/cache/apk/*
+
 
 # Copy python from builder image
 COPY --from=builder /usr/lib/python3.11/site-packages /usr/lib/python3.11/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone https://github.com/badaix/snapcast /snapcast
 
 # Build Snapcast
 WORKDIR /snapcast
-RUN cmake . \
+RUN cmake -DBUILD_SERVER=OFF . \
     && make
 
 RUN apk add --no-cache python3-dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       dockerfile: Dockerfile
     devices:
       - /dev/snd:/dev/snd
+    network_mode: host
     group_add:
       - 2001
     volumes:


### PR DESCRIPTION
These commits allow the docker container to be built successfully, locally. They go in tandem with https://github.com/hifiberry/snapcastmpris/pull/13

- Integrate Dockerfile from https://github.com/hifiberry/hifiberry-os/issues/548 and add openssl package to allow building snapclient.
- Fix path to snapcastmpris, as the newest commits on that repo put the files in a subfolder.
- Gave the container host network access. This is not optimal but it allows zeroconf to work.
- Improved build performance by only building snapclient and skipping snapserver.

There are still issues. The snapcastmpris config file is not generated correctly when installing the extension (and even when manually adding it, there is a read error). Further, snapcast is not visible as a provider in the UI.
But at least things work.